### PR TITLE
Fix banner contrast

### DIFF
--- a/data/com.github.manexim.home.appdata.xml.in
+++ b/data/com.github.manexim.home.appdata.xml.in
@@ -104,7 +104,7 @@
   <url type="bugtracker">https://github.com/manexim/home/issues</url>
   <custom>
     <!-- elementary AppCenter specific values -->
-    <value key="x-appcenter-color-primary">#4fad51</value>
+    <value key="x-appcenter-color-primary">#fafafa</value>
     <value key="x-appcenter-color-primary-text">#333</value>
     <!-- Suggested price in USD; just a suggestion, NOT a minimum. -->
     <value key="x-appcenter-suggested-price">5</value>


### PR DESCRIPTION
![Screenshot from 2019-07-09 20-55-56](https://user-images.githubusercontent.com/26003928/60886224-59f72100-a28c-11e9-8cc9-f3a0547ea6e6.png)

I think the current color of the app icon and the background color is difficult to distinguish because they have similar colors. This PR changes the latter color to white to fix their contrast.
