### PR TITLE
Improve contrast in the AppCenter Banner

### DIFF
--- a/data/com.github.manexim.home.appdata.xml.in
+++ b/data/com.github.manexim.home.appdata.xml.in
@@ -104,7 +104,7 @@
   <url type="bugtracker">https://github.com/manexim/home/issues</url>
   <custom>
     <!-- elementary AppCenter specific values -->
-    <value key="x-appcenter-color-primary">#4fad51</value>
+    <value key="x-appcenter-color-primary">#a5d6a6</value>
     <value key="x-appcenter-color-primary-text">#333</value>
     <!-- Suggested price in USD; just a suggestion, NOT a minimum. -->
     <value key="x-appcenter-suggested-price">5</value>


### PR DESCRIPTION
As it stands, the color chosen for AppCenter's background color in this app's listing clashes with the app's icon. I fixed this with this PR.