### PR TITLE
Set Node.js version to 10.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 10/*
+  - 10.17.0
 
 sudo: required
 


### PR DESCRIPTION
A segmentation fault occurs when running Houston CI on Travis CI. As a temporary fix Node.js can be downgraded to version 10.17.0.

There is an open Houston issue: [elementary/houston#773](https://github.com/elementary/houston/issues/773)

Thanks to [@peteruithoven](https://github.com/peteruithoven) for posting the temporary solution in the issue and to [@raibtoffoletto](https://github.com/raibtoffoletto) for posting it on Gitter.